### PR TITLE
Introduce pandas, update CLI wrapper, and provide documentation

### DIFF
--- a/thesiscentral-vireo/dataspace/python/restrictionsFindIds.py
+++ b/thesiscentral-vireo/dataspace/python/restrictionsFindIds.py
@@ -1,157 +1,94 @@
-import argparse
-import logging
-import traceback
-import sys
+"""
+A CLI wrapper for match_ids, a function that looks through the export_file to
+ see if there are any submissions that match in restrictions_file. It exports
+ the department's restricted submissions to output_file.
+
+The default inputs and outputs match the directory structure proposed for the
+ current workflow; however, they can be overwritten by command line arguments.
+
+An example shell command:
+
+python restrictionsFindIds.py --department English
+
+"""
+
+import pandas as pd
 import os
-import pdb
-
-# For the benefit of IDE import two ways
-try:
-    from vireo import VireoSheet
-except Exception as import_error:
-    pdb.set_trace()
-    from .vireo import VireoSheet
-
-EXPORT_STATUS = ['Approved']
+import argparse
 
 class ArgParser(argparse.ArgumentParser):
     @staticmethod
     def create():
         description = """
-read thesis submission info from file given in --thesis option 
-read access restriction info from --restrictions file 
+reate an Excel spreadsheet 
+Read thesis submission info from file given in --thesis option 
+Read access restriction info from --restrictions file 
 
 fill ID column values where they are None with the submission ID of the matching thesis submission 
 
 """
-        loglevels = ['CRITICAL', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'NOTSET']
-
         parser = ArgParser(description=description, formatter_class=argparse.RawTextHelpFormatter)
-        parser.add_argument("--thesis", "-t", required=True, help="excel export file from vireo")
-        parser.add_argument("--restrictions", "-r", required=True, help="TODO access restrictions")
-        parser.add_argument("--loglevel", "-l", choices=loglevels,  default=logging.INFO, help="log level  - default: ERROR")
-        return parser;
+        parser.add_argument('--department', "-d", required=True, help="The department to search for IDs")
+        parser.add_argument("--thesis", "-t", required=False, help="Excel export file from vireo", default=None)
+        parser.add_argument("--restrictions", "-r", required=False, help="Access restrictions spreadsheet", default='downloads/Restrictions.xlsx')
+        parser.add_argument("--output", "-o", required=False, help="The output spreadsheet", default=None)
+        return parser
 
     def parse_args(self):
         args= argparse.ArgumentParser.parse_args(self)
         return args
 
-def choose(matches, vireo, print_col_names):
-    if(len(matches) < 1):
-        return None
+def match_ids(department,
+        restrictions_file='downloads/Restrictions.xlsx',
+        output_file='ImportRestrictions.xlsx',
+        export_file=None
+    ):
+    """Look through the export_file to see if there are any submissions that
+     match in restrictions_file. Export the department's restricted submissions
+     to output_file.
+    """
 
-    print("You have the following choices:")
+    def vireoName(r_name):
+        splts = r_name.split();
+        return '%s, %s' % (splts[-1], splts[0])
 
-    for m in matches:
-        i = 0
-
-        for p in print_col_names:
-            i = i + 1
-            try:
-                idx = vireo.col_index_of(p)
-                cell_value = m[idx].value.encode('utf-8')
-                option_value = str(cell_value).strip()
-                print("option %d --  %s" % (i, option_value))
-            except Exception as inst:
-                import pdb; pdb.set_trace()
-                pass
-
-    choice_input = raw_input("WHAT DO YOU WANT ? (return or now choice) > ")
-    choice = int(choice_input)
-    try:
-        if (choice > 0 and choice <= i):
-            return matches[choice - 1]
+    def raise_choice(id_list):
+        if len(id_list) == 0:
+            return None
+        if len(id_list) == 1:
+            return str(id_list[0])
         else:
-            print("%d is invalid - try again" % choice)
-            return choose(matches, vireo, print_col_names)
-    except Exception as e:
-        import pdb; pdb.set_trace()
-        print("An error has been encountered: %s" % e.message)
-        return None
+            # TODO: Check if titles or departments match before raising error
+            print(id_list)
+            raise ValueError(
+                "Two students with the same name exist." +
+                " You'll need to manually determine their PUID."
+            )
 
-def save(vireo):
-    try:
-        current_file_path = os.path.abspath(__file__)
-        parent_directory = os.path.abspath(os.path.join(current_file_path, os.pardir))
-        default_path = os.path.abspath(os.path.join( parent_directory, "ImportRestrictions.xlsx" ))
+    export_file = 'downloads/{}/ExcelExport.xlsx'.format(department) if export_file is None else export_file
+    output_file = 'export/{}/RestrictionsWithId.xlsx'.format(department) if output_file is None else output_file
 
-        choice_input = raw_input("SAVE to File ? enter filename (RETURN defaults to " + default_path + ") > ")
-        choice = choice_input.strip()
+    # import restrictions and export spreadsheets
+    df_r = pd.read_excel(restrictions_file)
+    df_e = pd.read_excel(export_file)
 
-        if ("" != choice):
-            vireo.save(choice)
-        else:
-            vireo.save(default_path)
-    except Exception as inst:
-        import pdb; pdb.set_trace()
-        pass
+    # Link the IDs between the two spreadsheets
+    df_r['ID'] = [df_e[df_e['Student name'] == vireoName(r['Submitted By'])]['Student ID'].tolist() for i, r in df_r.iterrows()]
+    df_r['ID'] = df_r['ID'].apply(raise_choice)
 
-def vireoName(r_name):
-    splts = r_name.split();
-    return '%s, %s' % (splts[-1], splts[0])
-
-def matchIds(submissions, restrictions):
-    r_id_idx = restrictions.id_col
-    r_name_idx = restrictions.col_index_of(VireoSheet.R_STUDENT_NAME)
-    r_title_idx = restrictions.col_index_of(VireoSheet.R_TITLE)
-    s_col_ids = [submissions.col_index_of(col) for col in [VireoSheet.STUDENT_NAME, VireoSheet.DOCUMENT_TITLE]]
-
-    # Iterator over rows in restrictions workbook
-    # propose matches
-    # update whith user choice
-    iter = restrictions._sheet.iter_rows()
-    _ = next(iter)  # throw header row away
-    for row in iter:
-        r_name = row[r_name_idx].value.encode('utf-8')
-        print("----------------------------------------------")
-        title_value = row[r_title_idx].value.encode('utf-8')
-        print("RESTRICTION Requested\n%s\n         --  %s" %(r_name, title_value))
-        s_id = row[r_id_idx].value
-
-        # If the ID needs to be assigned...
-        if (None == s_id):
-            s_name = vireoName( r_name )
-
-            matches = submissions.matchingRows(VireoSheet.STUDENT_NAME, s_name)
-            m = choose(matches, submissions, [VireoSheet.STUDENT_NAME, VireoSheet.DOCUMENT_TITLE])
-
-            if (len(matches) > 0 and m != None):
-                row[r_id_idx].value = m[0].value
-                print("The ID %s was matched" % (m[0].value))
-            else:
-                print("No ID matches were for found for %s" % (s_name))
-
-            print("--")
-        else:
-            match = submissions.id_rows[int(s_id)][0]
-            print("\nMATCHED Submission")
-            print("\n         --  ".join([str(match[id].value) for id in s_col_ids]))
-            raw_input("\nENTER to continue > ")
-    print("----------------------------------------------")
-    save(restrictions)
+    # Drop all rows that don't contain IDs and output new spreadsheet
+    df_r = df_r[~pd.isna(df_r['ID'])]
+    df_r.to_excel(output_file, index=False)
 
 def main():
+    parser = ArgParser.create()
+    args = parser.parse_args()
 
-    try:
-        parser = ArgParser.create()
-        args = parser.parse_args()
-
-        logging.getLogger().setLevel(args.loglevel)
-        logging.basicConfig()
-
-        submissions = VireoSheet.createFromExcelFile(args.thesis)
-        submissions.col_index_of(VireoSheet.MULTI_AUTHOR)
-        submissions.log_info()
-
-        restrictions = submissions.readRestrictions(args.restrictions, check_id=False)
-        restrictions.log_info()
-
-        matchIds(submissions, restrictions)
-
-    except Exception as e:
-        logging.error(e)
-        logging.debug(traceback.format_exc())
-        sys.exit(1)
+    match_ids(args.department,
+        restrictions_file=args.restrictions,
+        output_file=args.output,
+        export_file=args.thesis
+    )
 
 if __name__ == "__main__":
     main()

--- a/thesiscentral-vireo/dataspace/python/restrictionsFindIds.py
+++ b/thesiscentral-vireo/dataspace/python/restrictionsFindIds.py
@@ -19,14 +19,10 @@ import argparse
 class ArgParser(argparse.ArgumentParser):
     @staticmethod
     def create():
-        description = """
-reate an Excel spreadsheet 
-Read thesis submission info from file given in --thesis option 
-Read access restriction info from --restrictions file 
+        description = """A CLI wrapper for match_ids, a function that looks through the export_file to
+ see if there are any submissions that match in restrictions_file. It exports
+ the department's restricted submissions to output_file."""
 
-fill ID column values where they are None with the submission ID of the matching thesis submission 
-
-"""
         parser = ArgParser(description=description, formatter_class=argparse.RawTextHelpFormatter)
         parser.add_argument('--department', "-d", required=True, help="The department to search for IDs")
         parser.add_argument("--thesis", "-t", required=False, help="Excel export file from vireo", default=None)


### PR DESCRIPTION
Hopefully this PR will remove the need for us to add that ID column to the restrictions spreadsheet. In this new workflow, I'm not saving `ImportRestrictions.xlsx` to the top level directory. I instead save it directly to the department's export directory. Was there a particular need for it? It's pretty straightforward to keep it if necessary.

To be more clear about the purpose of output spreadsheet, I just filtered out any restrictions that weren't applicable to the department. So as we export to the English directory, the restrictions spreadsheet will only contain English restrictions. 

I haven't changed the import readme, because I'm afraid of merge conflicts. But I will do that as soon as this is settled.

I didn't find the logging particularly useful. So I didn't include it. Do you recommend we keep it?

I'm going to keep this as a draft until we confirm that it's not too much trouble to add a unique student identifier to the restrictions spreadsheet. I currently just raise an error if there are multiple name matches. 

Going forward I'd like to add schema validation to make sure that the input excel spreadsheets have the expected structure.